### PR TITLE
ci: multi-arch docker buildx

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -44,9 +44,11 @@ jobs:
             type=sha,prefix={{tag}}-
       
       - name: Build and push multi-arch image
+        id: build
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: .
+          file: ./Dockerfile.multiarch
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -1,0 +1,64 @@
+name: docker-buildx
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker-buildx-multiarch:
+    name: release:docker-buildx
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write  # For OIDC attestations
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.8.0
+      
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix={{tag}}-
+      
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+          
+      - name: Generate attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -1,0 +1,48 @@
+# Multi-stage build for multi-arch support
+ARG RUST_VERSION=1.88
+ARG DEBIAN_VERSION=bookworm-slim
+
+# Build stage
+FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION}-slim AS builder
+
+ARG TARGETARCH
+ARG TARGETOS
+
+# Install cross-compilation tools
+RUN apt-get update && apt-get install -y \
+    gcc-aarch64-linux-gnu \
+    gcc-x86-64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy manifests
+COPY Cargo.toml Cargo.lock ./
+
+# Copy source
+COPY src ./src
+
+# Set target based on TARGETARCH
+RUN case "$TARGETARCH" in \
+        amd64) TARGET="x86_64-unknown-linux-gnu" ;; \
+        arm64) TARGET="aarch64-unknown-linux-gnu" ;; \
+        *) echo "Unsupported architecture: $TARGETARCH" && exit 1 ;; \
+    esac && \
+    rustup target add $TARGET && \
+    cargo build --release --locked --target $TARGET && \
+    cp target/$TARGET/release/bootstrapped /bootstrapped
+
+# Runtime stage
+FROM debian:${DEBIAN_VERSION}
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /bootstrapped /usr/local/bin/bootstrapped
+
+# Add non-root user
+RUN useradd -m -u 1000 appuser
+USER appuser
+
+ENTRYPOINT ["/usr/local/bin/bootstrapped"]


### PR DESCRIPTION
## Summary
- Add docker buildx workflow for tags
- Support linux/amd64 and linux/arm64
- Enable provenance and SBOM generation
- Use GitHub Container Registry (ghcr.io)

Implements MASTER.md Operations requirements for multi-arch builds.

One-line rollback: `git revert c27fdf055ac9283b7dc933216efe9e51cee0bbd8`